### PR TITLE
Distinguish 'x' and b'x' in Python 2

### DIFF
--- a/ast27/Include/Python-ast.h
+++ b/ast27/Include/Python-ast.h
@@ -286,6 +286,7 @@ struct _expr {
                 
                 struct {
                         string s;
+                        int has_b;
                 } Str;
                 
                 struct {
@@ -503,8 +504,8 @@ expr_ty _Ta27_Call(expr_ty func, asdl_seq * args, asdl_seq * keywords, expr_ty s
 expr_ty _Ta27_Repr(expr_ty value, int lineno, int col_offset, PyArena *arena);
 #define Num(a0, a1, a2, a3) _Ta27_Num(a0, a1, a2, a3)
 expr_ty _Ta27_Num(object n, int lineno, int col_offset, PyArena *arena);
-#define Str(a0, a1, a2, a3) _Ta27_Str(a0, a1, a2, a3)
-expr_ty _Ta27_Str(string s, int lineno, int col_offset, PyArena *arena);
+#define Str(a0, a1, a2, a3, a4) _Ta27_Str(a0, a1, a2, a3, a4)
+expr_ty _Ta27_Str(string s, int has_b, int lineno, int col_offset, PyArena *arena);
 #define Attribute(a0, a1, a2, a3, a4, a5) _Ta27_Attribute(a0, a1, a2, a3, a4, a5)
 expr_ty _Ta27_Attribute(expr_ty value, identifier attr, expr_context_ty ctx, int lineno, int
                         col_offset, PyArena *arena);

--- a/ast27/Parser/Python.asdl
+++ b/ast27/Parser/Python.asdl
@@ -71,7 +71,7 @@ module Python version "$Revision$"
 			 expr? starargs, expr? kwargs)
 	     | Repr(expr value)
 	     | Num(object n) -- a number as a PyObject.
-	     | Str(string s) -- need to specify raw, unicode, etc?
+	     | Str(string s, int? has_b) -- need to specify raw, unicode, etc?
 	     -- other literals? bools?
 
 	     -- the following expression can appear in assignment context

--- a/ast27/Python/ast.c
+++ b/ast27/Python/ast.c
@@ -1499,6 +1499,9 @@ ast_for_atom(struct compiling *c, const node *n)
     }
     case STRING: {
         PyObject *str = parsestrplus(c, n);
+        const char *s = STR(CHILD(n, 0));
+        int quote = Py_CHARMASK(*s);
+        int has_b = 0;
         if (!str) {
 #ifdef Py_USING_UNICODE
             if (PyErr_ExceptionMatches(PyExc_UnicodeError)){
@@ -1523,7 +1526,10 @@ ast_for_atom(struct compiling *c, const node *n)
             return NULL;
         }
         PyArena_AddPyObject(c->c_arena, str);
-        return Str(str, LINENO(n), n->n_col_offset, c->c_arena);
+        if (quote == 'b' || quote == 'B') {
+            has_b = 1;
+        }
+        return Str(str, has_b, LINENO(n), n->n_col_offset, c->c_arena);
     }
     case NUMBER: {
         PyObject *pynum = parsenumber(c, STR(ch));


### PR DESCRIPTION
Fixes #10 

@gvanrossum @JukkaL @ddfisher 
This is a naive fix. It only checks the first string in concatenation at CST level, for ``b`` or ``B`` prefix and sets the ``has_b`` flag in ``Str`` AST node accordingly.